### PR TITLE
UX enhanchment. Introduce base divider for prepopulated collapsed menu items

### DIFF
--- a/packages/terra-collapsible-menu-view/CHANGELOG.md
+++ b/packages/terra-collapsible-menu-view/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Added
-  * Added `alwaysCollapsedMenuItems` attribute to `CollapsibleMenuView` which can be used to prepopulate collapsible menu view. These items will always hidden under the More button. The collapsed menu view will always shown if at least one item is added to the collapsedMenuItems list. 
+  * Added `alwaysCollapsedMenuItems` attribute to `CollapsibleMenuView` which can be used to prepopulate collapsible menu view. These items will always hidden under the More button. The collapsed menu view will always shown if at least one item is added to the collapsedMenuItems list. A divider will shown if there are other elements pushed to the collapsed menu view to divide them from the prepopulated list. 
 
 * Changed
   * Updated to support a peer dependency of react-intl v2-v5

--- a/packages/terra-collapsible-menu-view/src/CollapsibleMenuView.jsx
+++ b/packages/terra-collapsible-menu-view/src/CollapsibleMenuView.jsx
@@ -46,6 +46,8 @@ const defaultProps = {
   alwaysCollapsedMenuItems: [],
 };
 
+const prepopulatedBaseDivider = <CollapsibleMenuViewDivider key="prepopulatedBaseDivider" />;
+
 class CollapsibleMenuView extends React.Component {
   constructor(props) {
     super(props);
@@ -160,7 +162,7 @@ class CollapsibleMenuView extends React.Component {
 
     if (this.hiddenStartIndex >= 0) {
       visibleChildren = React.Children.toArray(children);
-      hiddenChildren = visibleChildren.splice(this.hiddenStartIndex).concat(hiddenChildren);
+      hiddenChildren = visibleChildren.splice(this.hiddenStartIndex).concat(prepopulatedBaseDivider).concat(hiddenChildren);
     }
 
     return (

--- a/packages/terra-collapsible-menu-view/src/terra-dev-site/doc/example/CollapsibleMenuViewDemo.jsx
+++ b/packages/terra-collapsible-menu-view/src/terra-dev-site/doc/example/CollapsibleMenuViewDemo.jsx
@@ -37,7 +37,6 @@ class CollapsibleMenuViewDemo extends React.Component {
     return (
       <CollapsibleMenuView
         alwaysCollapsedMenuItems={[
-          <CollapsibleMenuView.Divider key="CollapsedDivider" />,
           <CollapsibleMenuView.Item text="Collapsed Button 1" key="collapsedButton1" />,
           <CollapsibleMenuView.Item text="Collapsed Button 2" key="collapsedButton2" />,
           <CollapsibleMenuView.Item text="Collapsed Button 3" key="collapsedButton3" />,


### PR DESCRIPTION
### Summary
UX enhanchment. Show a base divider to separate the prepopulated items from the items which are pushed to the collapsed menu view because of the lack of space.
